### PR TITLE
Add authorize to createReceiver() convenience method

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports.createReceiver = function( params ) {
 	var transConfig = params.transports;
 
 	var receiver = new this.Receiver( {
+		authorize: params.authorize,
 		baseDir: params.baseDir
 	} );
 


### PR DESCRIPTION
Fixes an issue with the authorize method not getting passed through when creating a new receiver. 
